### PR TITLE
Allow any whitespace as filename separator

### DIFF
--- a/src/main/java/org/nette/latte/inspections/MissingFileInspection.java
+++ b/src/main/java/org/nette/latte/inspections/MissingFileInspection.java
@@ -42,7 +42,7 @@ public class MissingFileInspection extends BaseLocalInspectionTool {
 				if (element instanceof LatteMacroTag && tags.contains(((LatteMacroTag) element).getMacroName())) {
 					LatteMacroContent macroContent = PsiTreeUtil.findChildOfType(element, LatteMacroContent.class);
 					if (macroContent != null) {
-						String text = macroContent.getText().split(" ")[0].split(",")[0];
+						String text = macroContent.getText().split("\\s")[0].split(",")[0];
 						if (!text.contains("$") && text.contains(".")) {
 							String relativePath = text.replaceAll("[\"']", "").trim();
 


### PR DESCRIPTION
I have this code:

```latte
{include includes/userFilmReviews.latte
	userFilmReviews => $filmReviewsFavoriteUsers
}
```

There's a newline and a tab.